### PR TITLE
Fix: remove transaction work because of duplication error

### DIFF
--- a/api/notd/manager.py
+++ b/api/notd/manager.py
@@ -125,7 +125,7 @@ class NotdManager:
 
     async def receive_new_blocks(self) -> None:
         latestTokenTransfers = await self.retriever.list_token_transfers(orders=[Order(fieldName=TokenTransfersTable.c.blockNumber.key, direction=Direction.DESCENDING)], limit=1)
-        latestProcessedBlockNumber = 13140000 #latestTokenTransfers[0].blockNumber
+        latestProcessedBlockNumber = latestTokenTransfers[0].blockNumber
         latestBlockNumber = await self.blockProcessor.get_latest_block_number()
         logging.info(f'Scheduling messages for processing blocks from {latestProcessedBlockNumber} to {latestBlockNumber}')
         batchSize = 3

--- a/api/notd/manager.py
+++ b/api/notd/manager.py
@@ -13,7 +13,6 @@ from core.store.retriever import Order
 from core.store.retriever import RandomOrder
 from core.store.retriever import StringFieldFilter
 from core.util import date_util
-from core.util import list_util
 
 from notd.block_processor import BlockProcessor
 from notd.messages import ProcessBlockRangeMessageContent
@@ -126,10 +125,10 @@ class NotdManager:
 
     async def receive_new_blocks(self) -> None:
         latestTokenTransfers = await self.retriever.list_token_transfers(orders=[Order(fieldName=TokenTransfersTable.c.blockNumber.key, direction=Direction.DESCENDING)], limit=1)
-        latestProcessedBlockNumber = latestTokenTransfers[0].blockNumber
+        latestProcessedBlockNumber = 13140000 #latestTokenTransfers[0].blockNumber
         latestBlockNumber = await self.blockProcessor.get_latest_block_number()
         logging.info(f'Scheduling messages for processing blocks from {latestProcessedBlockNumber} to {latestBlockNumber}')
-        batchSize = 2
+        batchSize = 3
         for startBlockNumber in reversed(range(latestProcessedBlockNumber, latestBlockNumber + 1, batchSize)):
             endBlockNumber = min(startBlockNumber + batchSize, latestBlockNumber + 1)
             await self.workQueue.send_message(message=ProcessBlockRangeMessageContent(startBlockNumber=startBlockNumber, endBlockNumber=endBlockNumber).to_message())
@@ -143,7 +142,7 @@ class NotdManager:
 
     async def _create_token_transfer(self, retrievedTokenTransfer: RetrievedTokenTransfer) -> None:
         try:
-            await self.saver.create_token_transfer(transactionHash=retrievedTokenTransfer.transactionHash, registryAddress=retrievedTokenTransfer.registryAddress, fromAddress=retrievedTokenTransfer.fromAddress, toAddress=retrievedTokenTransfer.toAddress, tokenId=retrievedTokenTransfer.tokenId, value=retrievedTokenTransfer.value, gasLimit=retrievedTokenTransfer.gasLimit, gasPrice=retrievedTokenTransfer.gasPrice, gasUsed=retrievedTokenTransfer.gasUsed, blockNumber=retrievedTokenTransfer.blockNumber, blockHash=retrievedTokenTransfer.blockHash, blockDate=retrievedTokenTransfer.blockDate)
+            await self.saver.create_token_transfer(retrievedTokenTransfer=retrievedTokenTransfer)
         except DuplicateValueException:
             logging.debug('Ignoring previously saved transfer')
 
@@ -155,11 +154,7 @@ class NotdManager:
             logging.debug(f'Paid {retrievedTokenTransfer.value / 100000000000000000.0}Ξ ({retrievedTokenTransfer.gasUsed * retrievedTokenTransfer.gasPrice / 100000000000000000.0}Ξ) to {retrievedTokenTransfer.registryAddress}')
             logging.debug(f'OpenSea url: https://opensea.io/assets/{retrievedTokenTransfer.registryAddress}/{retrievedTokenTransfer.tokenId}')
             logging.debug(f'OpenSea api url: https://api.opensea.io/api/v1/asset/{retrievedTokenTransfer.registryAddress}/{retrievedTokenTransfer.tokenId}')
-        async with self.saver.transaction():
-            # NOTE(krishan711): figure out why this gathering doesn't work
-            # await asyncio.gather(*[self._create_token_transfer(retrievedTokenTransfer=retrievedTokenTransfer) for retrievedTokenTransfer in retrievedTokenTransfers])
-            for retrievedTokenTransfer in retrievedTokenTransfers:
-                self._create_token_transfer(retrievedTokenTransfer=retrievedTokenTransfer)
+        await asyncio.gather(*[self._create_token_transfer(retrievedTokenTransfer=retrievedTokenTransfer) for retrievedTokenTransfer in retrievedTokenTransfers])
 
     async def retreive_registry_token(self, registryAddress: str, tokenId: str) -> RegistryToken:
         cacheKey = f'{registryAddress}:{tokenId}'

--- a/api/notd/model.py
+++ b/api/notd/model.py
@@ -7,8 +7,7 @@ from pydantic import dataclasses
 
 
 @dataclasses.dataclass
-class TokenTransfer:
-    tokenTransferId: int
+class RetrievedTokenTransfer:
     transactionHash: str
     registryAddress: str
     fromAddress: str
@@ -21,6 +20,10 @@ class TokenTransfer:
     blockNumber: int
     blockHash: str
     blockDate: datetime.datetime
+
+@dataclasses.dataclass
+class TokenTransfer(RetrievedTokenTransfer):
+    tokenTransferId: int
 
     def to_dict(self) -> Dict:
         return {
@@ -39,20 +42,6 @@ class TokenTransfer:
             'blockDate': self.blockDate.isoformat(),
         }
 
-@dataclasses.dataclass
-class RetrievedTokenTransfer:
-    transactionHash: str
-    registryAddress: str
-    fromAddress: str
-    toAddress: str
-    tokenId: str
-    value: int
-    gasLimit: int
-    gasPrice: int
-    gasUsed: int
-    blockNumber: int
-    blockHash: str
-    blockDate: datetime.datetime
 
 @dataclasses.dataclass
 class Token:

--- a/api/notd/store/saver.py
+++ b/api/notd/store/saver.py
@@ -3,36 +3,51 @@ import datetime
 
 from core.store.saver import Saver as CoreSaver
 
-from notd.model import TokenTransfer
+from notd.model import RetrievedTokenTransfer, TokenTransfer
 from notd.store.schema import TokenTransfersTable
 
 
 class Saver(CoreSaver):
 
     @contextlib.asynccontextmanager
-    async def transaction(self):
+    async def create_transaction(self):
         transaction = self.database.transaction()
         try:
             await transaction.start()
             yield None
-            await transaction.commit()
         except:
             await transaction.rollback()
             raise
+        else:
+            await transaction.commit()
 
-    async def create_token_transfer(self, transactionHash: str, registryAddress: str, fromAddress: str, toAddress: str, tokenId: int, value: int, gasLimit: int, gasPrice: int, gasUsed: int, blockNumber: int, blockHash: str, blockDate: datetime.datetime) -> TokenTransfer:
+    async def create_token_transfer(self, retrievedTokenTransfer: RetrievedTokenTransfer) -> TokenTransfer:
         tokenTransferId = await self._execute(query=TokenTransfersTable.insert(), values={  # pylint: disable=no-value-for-parameter
-            TokenTransfersTable.c.transactionHash.key: transactionHash,
-            TokenTransfersTable.c.registryAddress.key: registryAddress,
-            TokenTransfersTable.c.fromAddress.key: fromAddress,
-            TokenTransfersTable.c.toAddress.key: toAddress,
-            TokenTransfersTable.c.tokenId.key: tokenId,
-            TokenTransfersTable.c.value.key: value,
-            TokenTransfersTable.c.gasLimit.key: gasLimit,
-            TokenTransfersTable.c.gasPrice.key: gasPrice,
-            TokenTransfersTable.c.gasUsed.key: gasUsed,
-            TokenTransfersTable.c.blockNumber.key: blockNumber,
-            TokenTransfersTable.c.blockHash.key: blockHash,
-            TokenTransfersTable.c.blockDate.key: blockDate,
+            TokenTransfersTable.c.transactionHash.key: retrievedTokenTransfer.transactionHash,
+            TokenTransfersTable.c.registryAddress.key: retrievedTokenTransfer.registryAddress,
+            TokenTransfersTable.c.fromAddress.key: retrievedTokenTransfer.fromAddress,
+            TokenTransfersTable.c.toAddress.key: retrievedTokenTransfer.toAddress,
+            TokenTransfersTable.c.tokenId.key: retrievedTokenTransfer.tokenId,
+            TokenTransfersTable.c.value.key: retrievedTokenTransfer.value,
+            TokenTransfersTable.c.gasLimit.key: retrievedTokenTransfer.gasLimit,
+            TokenTransfersTable.c.gasPrice.key: retrievedTokenTransfer.gasPrice,
+            TokenTransfersTable.c.gasUsed.key: retrievedTokenTransfer.gasUsed,
+            TokenTransfersTable.c.blockNumber.key: retrievedTokenTransfer.blockNumber,
+            TokenTransfersTable.c.blockHash.key: retrievedTokenTransfer.blockHash,
+            TokenTransfersTable.c.blockDate.key: retrievedTokenTransfer.blockDate,
         })
-        return TokenTransfer(tokenTransferId=tokenTransferId, transactionHash=transactionHash, registryAddress=registryAddress, fromAddress=fromAddress, toAddress=toAddress, tokenId=tokenId, value=value, gasLimit=gasLimit, gasPrice=gasPrice, gasUsed=gasUsed, blockNumber=blockNumber, blockHash=blockHash, blockDate=blockDate)
+        return TokenTransfer(
+            tokenTransferId=tokenTransferId,
+            transactionHash=retrievedTokenTransfer.transactionHash,
+            registryAddress=retrievedTokenTransfer.registryAddress,
+            fromAddress=retrievedTokenTransfer.fromAddress,
+            toAddress=retrievedTokenTransfer.toAddress,
+            tokenId=retrievedTokenTransfer.tokenId,
+            value=retrievedTokenTransfer.value,
+            gasLimit=retrievedTokenTransfer.gasLimit,
+            gasPrice=retrievedTokenTransfer.gasPrice,
+            gasUsed=retrievedTokenTransfer.gasUsed,
+            blockNumber=retrievedTokenTransfer.blockNumber,
+            blockHash=retrievedTokenTransfer.blockHash,
+            blockDate=retrievedTokenTransfer.blockDate,
+        )

--- a/api/notd/store/saver.py
+++ b/api/notd/store/saver.py
@@ -1,9 +1,9 @@
 import contextlib
-import datetime
 
 from core.store.saver import Saver as CoreSaver
 
-from notd.model import RetrievedTokenTransfer, TokenTransfer
+from notd.model import RetrievedTokenTransfer
+from notd.model import TokenTransfer
 from notd.store.schema import TokenTransfersTable
 
 

--- a/api/notd/store/schema.py
+++ b/api/notd/store/schema.py
@@ -2,9 +2,7 @@ import sqlalchemy
 
 metadata = sqlalchemy.MetaData()
 
-TokenTransfersTable = sqlalchemy.Table(
-    'tbl_token_transfers',
-    metadata,
+TokenTransfersTable = sqlalchemy.Table('tbl_token_transfers', metadata,
     sqlalchemy.Column(key='tokenTransferId', name='id', type_=sqlalchemy.Integer, autoincrement=True, primary_key=True, nullable=False),
     sqlalchemy.Column(key='transactionHash', name='transaction_hash', type_=sqlalchemy.Text, nullable=False),
     sqlalchemy.Column(key='registryAddress', name='registry_address', type_=sqlalchemy.Text, nullable=False),


### PR DESCRIPTION
We handle duplicates at a python level by allowing psql to throw an error and catching it in python. This however causes the psql transaction to be "aborted" (even though the rollback won't happen) so makes everything fail.