### PR TITLE
Feature: Truncate Title of tokens in NftCard

### DIFF
--- a/app/src/components/nftCard.tsx
+++ b/app/src/components/nftCard.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Alignment, Box, Button, Direction, Image, MarkdownText, Media, PaddingSize, Spacing, Stack, Text, TextAlignment, WebView } from '@kibalabs/ui-react';
 
 import { RegistryToken } from '../client/resources';
+import { truncateTitle } from '../titleUtil';
 import { shouldUseIframe } from './nftUtil';
 
 export interface NftCardProps {
@@ -59,7 +60,7 @@ export const NftCard = (props: NftCardProps): React.ReactElement => {
                 )}
               </Box>
             </Stack.Item>
-            <Text variant='header3' alignment={TextAlignment.Center}>{title}</Text>
+            <Text variant='header3' alignment={TextAlignment.Center}>{truncateTitle(title)}</Text>
             <Text alignment={TextAlignment.Center}>{props.subtitle}</Text>
             <Spacing variant={PaddingSize.Wide} />
             {collectionTitle && (

--- a/app/src/titleUtil.ts
+++ b/app/src/titleUtil.ts
@@ -1,3 +1,4 @@
-export const truncateTitle = (title: string, maxLength = 50): string => (title.length > maxLength
-  ? `${title.substring(0, maxLength)}…`
-  : title);
+export const truncateTitle = (title: string, maxLength = 50): string => {
+  return (
+    title.length > maxLength ? `${title.substring(0, maxLength)}…` : title);
+};

--- a/app/src/titleUtil.ts
+++ b/app/src/titleUtil.ts
@@ -1,0 +1,3 @@
+export const truncateTitle = (title: string, maxLength = 50): string => (title.length > maxLength
+  ? `${title.substring(0, maxLength)}…`
+  : title);

--- a/app/src/titleUtil.ts
+++ b/app/src/titleUtil.ts
@@ -1,4 +1,3 @@
 export const truncateTitle = (title: string, maxLength = 50): string => {
-  return (
-    title.length > maxLength ? `${title.substring(0, maxLength)}…` : title);
+  return title.length > maxLength ? `${title.substring(0, maxLength)}…` : title;
 };


### PR DESCRIPTION
This Truncate title to 50 characters else it displays the title.
![image](https://user-images.githubusercontent.com/37664545/140909604-c0e6b031-1da9-4ebe-a0b0-13983228b877.png)
