### PR TITLE
Fiddle: Update backfill_collection_activities script to ignore already processed work

### DIFF
--- a/api/notd/notd_message_processor.py
+++ b/api/notd/notd_message_processor.py
@@ -61,6 +61,9 @@ class NotdMessageProcessor(MessageProcessor):
             await self.notdManager.update_activity_for_all_collections()
             return
         if message.command == UpdateActivityForCollectionMessageContent.get_command():
+            if message.postDate is None or message.postDate < date_util.datetime_from_now(seconds=-(60 * 10)):
+                logging.info(f'Skipping UPDATE_ACTIVITY_FOR_COLLECTION from more than 10 minutes ago')
+                return
             messageContent = UpdateActivityForCollectionMessageContent.parse_obj(message.content)
             await self.notdManager.update_activity_for_collection(address=messageContent.address, startDate=messageContent.startDate)
             return

--- a/api/scripts/backfill_collection_activities.py
+++ b/api/scripts/backfill_collection_activities.py
@@ -28,9 +28,7 @@ from notd.token_manager import TokenManager
 @click.option('-e', '--end-block-number', 'endBlock', required=True, type=int)
 @click.option('-b', '--batch-size', 'batchSize', required=False, type=int, default=500)
 async def backfill_collection_activities(startBlock: int, endBlock: int, batchSize: int):
-    databaseConnectionString = Database.create_psql_connection_string(username=os.environ["REMOTE_DB_USERNAME"], password=os.environ["REMOTE_DB_PASSWORD"], host=os.environ["REMOTE_DB_HOST"], port=os.environ["REMOTE_DB_PORT"], name=os.environ["REMOTE_DB_NAME"])
-
-    #databaseConnectionString = Database.create_psql_connection_string(username=os.environ["DB_USERNAME"], password=os.environ["DB_PASSWORD"], host=os.environ["DB_HOST"], port=os.environ["DB_PORT"], name=os.environ["DB_NAME"])
+    databaseConnectionString = Database.create_psql_connection_string(username=os.environ["DB_USERNAME"], password=os.environ["DB_PASSWORD"], host=os.environ["DB_HOST"], port=os.environ["DB_PORT"], name=os.environ["DB_NAME"])
     database = Database(connectionString=databaseConnectionString)
     retriever = Retriever(database=database)
     saver = Saver(database=database)

--- a/api/scripts/backfill_collection_activities.py
+++ b/api/scripts/backfill_collection_activities.py
@@ -58,6 +58,8 @@ async def backfill_collection_activities(startBlock: int, endBlock: int, batchSi
         processedPairs = {(collectionHourlyActivity.address, collectionHourlyActivity.date) for collectionHourlyActivity in collectionHourlyActivities}
         registryDatePairs = {(tokenTransfer.registryAddress, date_hour_from_datetime(tokenTransfer.blockDate)) for tokenTransfer in tokenTransfers if (tokenTransfer.registryAddress, date_hour_from_datetime(tokenTransfer.blockDate)) not in processedPairs}
         print(f'Processing {len(registryDatePairs)} pairs from {len(tokenTransfers)} transfers')
+        # messages = [UpdateActivityForCollectionMessageContent(address=address, startDate=startDate).to_message() for (address, startDate) in registryDatePairs]
+        # await tokenQueue.send_messages(messages=messages)
         for pairChunk in list_util.generate_chunks(lst=list(registryDatePairs), chunkSize=50):
             await asyncio.gather(*[tokenManager.update_activity_for_collection(address=registryAddress, startDate=startDate) for registryAddress, startDate in pairChunk])
         currentBlockNumber = endBlockNumber

--- a/api/scripts/backfill_collection_activities.py
+++ b/api/scripts/backfill_collection_activities.py
@@ -45,14 +45,14 @@ async def backfill_collection_activities(startBlock: int, endBlock: int, batchSi
         tokenTransfers = await retriever.list_token_transfers(
             fieldFilters=[
                 IntegerFieldFilter(BlocksTable.c.blockNumber.key, gte=currentBlockNumber),
-                IntegerFieldFilter(BlocksTable.c.blockNumber.key, lt=endBlockNumber),
+                IntegerFieldFilter(BlocksTable.c.blockNumber.key, lte=endBlockNumber),
             ],
             orders=[Order(fieldName=BlocksTable.c.blockDate.key, direction=Direction.ASCENDING)],
         )
         collectionHourlyActivities = await retriever.list_collections_activity(
             fieldFilters=[
-                DateFieldFilter(CollectionHourlyActivityTable.c.date.key, gte=tokenTransfers[0].blockDate),
-                DateFieldFilter(CollectionHourlyActivityTable.c.date.key, lte=tokenTransfers[-1].blockDate),
+                DateFieldFilter(CollectionHourlyActivityTable.c.date.key, gte=date_hour_from_datetime(tokenTransfers[0].blockDate)),
+                DateFieldFilter(CollectionHourlyActivityTable.c.date.key, lte=date_hour_from_datetime(tokenTransfers[-1].blockDate)),
             ],
         )
         processedPairs = {(collectionHourlyActivity.address, collectionHourlyActivity.date) for collectionHourlyActivity in collectionHourlyActivities}

--- a/api/scripts/backfill_collection_activities.py
+++ b/api/scripts/backfill_collection_activities.py
@@ -7,7 +7,7 @@ import sys
 import asyncclick as click
 from core.queues.sqs_message_queue import SqsMessageQueue
 from core.store.database import Database
-from core.store.retriever import  DateFieldFilter
+from core.store.retriever import DateFieldFilter
 from core.store.retriever import IntegerFieldFilter
 from core.util import list_util
 from core.store.retriever import Order

--- a/api/scripts/backfill_collection_activities.py
+++ b/api/scripts/backfill_collection_activities.py
@@ -56,9 +56,9 @@ async def backfill_collection_activities(startBlock: int, endBlock: int, batchSi
             ],
         )
         processedPairs = {(collectionHourlyActivity.address, collectionHourlyActivity.date) for collectionHourlyActivity in collectionHourlyActivities}
-        pairs = {(tokenTransfer.registryAddress, date_hour_from_datetime(tokenTransfer.blockDate)) for tokenTransfer in tokenTransfers if (tokenTransfer.registryAddress, date_hour_from_datetime(tokenTransfer.blockDate)) not in processedPairs}
-        print(len(pairs))
-        for pairChunk in list_util.generate_chunks(lst=list(pairs), chunkSize=10):
+        registryDatePairs = {(tokenTransfer.registryAddress, date_hour_from_datetime(tokenTransfer.blockDate)) for tokenTransfer in tokenTransfers if (tokenTransfer.registryAddress, date_hour_from_datetime(tokenTransfer.blockDate)) not in processedPairs}
+        print(f'Processing {len(registryDatePairs)} pairs from {len(tokenTransfers)} transfers')
+        for pairChunk in list_util.generate_chunks(lst=list(registryDatePairs), chunkSize=50):
             await asyncio.gather(*[tokenManager.update_activity_for_collection(address=registryAddress, startDate=startDate) for registryAddress, startDate in pairChunk])
         currentBlockNumber = endBlockNumber
 


### PR DESCRIPTION
So the thought process was to get a list of all address date pairs in the collection table and to filter those out from address date pairs in token transfers